### PR TITLE
Evan/frontend

### DIFF
--- a/client/src/DirectionSidebar.css
+++ b/client/src/DirectionSidebar.css
@@ -29,6 +29,23 @@
 
 .direction-button
 {
+    font-family: Cambria, Cochin, Georgia, Times, 'Times New Roman', serif;
+    font-size: 20px;
+
+    display: block;
+    margin: auto;
+    margin-top: 20px;
+    width: 50%;
+    padding: 10px;
+
+    border: none;
+    border-radius: 5px;
+    background-color: lightgray;
+    cursor: pointer;
+}
+.direction-button:hover
+{
+    background-color: gainsboro;
 }
 
 hr.line

--- a/client/src/DirectionSidebar.js
+++ b/client/src/DirectionSidebar.js
@@ -20,11 +20,15 @@ class DirectionSidebar extends Component {
         return (
             <div className = 'direction-container'>
                 <div className="direction-box">
-                    <h className="direction-text">From: </h>
-                    <Geocoder map = {this.props.map} />
+                    <div id="from-wrapper">
+                        <h className="direction-text">From: </h>
+                        <Geocoder map = {this.props.map} />
+                    </div>
                     <hr className="line"/>
-                    <h className="direction-text">To: </h>
-                    <Geocoder map = {this.props.map} />
+                    <div id="to-wrapper">
+                        <h className="direction-text">To: </h>
+                        <Geocoder map = {this.props.map} />
+                    </div>
  
                     <button className="direction-button" onClick={this.sendGeo}>
                         Get Direction

--- a/client/src/Geocoder.css
+++ b/client/src/Geocoder.css
@@ -87,21 +87,13 @@
 
 /* Suggestions */
 .mapboxgl-ctrl-geocoder .suggestions {
-  position: absolute !important; /* Not sure why it is not absolute */
   margin: 0;
   padding: 0;
   left: 0;
-  top: 137px !important;
-  /* top: 110%; fallback */
-  background-color: #fff;
   border-radius: 4px;
-  left: 0;
 
+  background-color: #FFF;
   list-style: none;
-
-  width: 100%;
-
-  z-index: 1000;
   overflow: hidden;
   font-size: 15px;
 }


### PR DESCRIPTION
Minor CSS changes to correct for Geocoder bug and Direction Siderbar styling

Ideally
Geocoder.js and
Geocoder.css 
should be completely rewritten to conform to React best practices in the future.

There is a lot of bloat in Geocoder.css, not all of which is necessary.