### PR TITLE
Parallelized map matching API calls + fixed failed match crash

### DIFF
--- a/client/src/Map.js
+++ b/client/src/Map.js
@@ -284,46 +284,50 @@ class Map extends Component {
     req.open('GET', url, true);
     req.onload = function () {
       const json = JSON.parse(req.response);
-      console.log(json);
-      that.setState({direction_list: json["turn-by-turn-directions"]});
-      that.setState({json_full: json});
-      var route = json.coordinates;
-      var geojson = {
-        type: 'Feature',
-        properties: {},
-        geometry: {
-          type: 'LineString',
-          coordinates: route
-        }
-      };
-      // render the route line
-      if (map.getSource('route')) {
-        map.getSource('route').setData(geojson);
+      //console.log(json);
+      if (json.success === false) {
+        alert("Error generating route - please try again! Error: " + json.error);
       } else {
-        map.addLayer({
-          id: 'route',
-          type: 'line',
-          source: {
-            type: 'geojson',
-            data: {
-              type: 'Feature',
-              properties: {},
-              geometry: {
-                type: 'LineString',
-                coordinates: route
-              }
-            }
-          },
-          layout: {
-            'line-join': 'round',
-            'line-cap': 'round'
-          },
-          paint: {
-            'line-color': '#3887be',
-            'line-width': 5,
-            'line-opacity': 0.75
+        that.setState({direction_list: json["turn-by-turn-directions"]});
+        that.setState({json_full: json});
+        var route = json.coordinates;
+        var geojson = {
+          type: 'Feature',
+          properties: {},
+          geometry: {
+            type: 'LineString',
+            coordinates: route
           }
-        });
+        };
+        // render the route line
+        if (map.getSource('route')) {
+          map.getSource('route').setData(geojson);
+        } else {
+          map.addLayer({
+            id: 'route',
+            type: 'line',
+            source: {
+              type: 'geojson',
+              data: {
+                type: 'Feature',
+                properties: {},
+                geometry: {
+                  type: 'LineString',
+                  coordinates: route
+                }
+              }
+            },
+            layout: {
+              'line-join': 'round',
+              'line-cap': 'round'
+            },
+            paint: {
+              'line-color': '#3887be',
+              'line-width': 5,
+              'line-opacity': 0.75
+            }
+          });
+        }
       }
       that.setState({dir_loading: false});
     }

--- a/server/navigation/router.js
+++ b/server/navigation/router.js
@@ -209,8 +209,8 @@ class Router {
 
   // accepts distances in kilometers
   generateCircularPath(start, dist, res, token){
-    if (dist > 16.1) {
-      this.processOutput("Error: only supports distances within 10 miles for now")
+    if (dist > 60.1) {
+      this.processOutput("Error: distance too long", res, token)
       return;
     }
     var maxDistanceMatch = 0.1; //km


### PR DESCRIPTION
- Parallelized map matching API calls (now, calls all at once, instead of waiting for one to finish before executing the next - can save 2+ seconds per 100 coords for longer routes!)
- When Mapbox API failed earlier, our routing crashed, but now it handles the error properly
- Frontend alert issued if routing error occurs (earlier was silent)